### PR TITLE
chore/bugfix: update rm version

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -61,8 +61,7 @@ jobs:
         --sdm conda \
         --conda-frontend conda \
         --configfile test/config/config.yaml \
-        --show-failed-logs \
-        --all-temp
+        --show-failed-logs && rm -rf results
 
     - name: Test run chr8 and chr21 workflow using provided RM output.
       run: |
@@ -70,5 +69,4 @@ jobs:
         --sdm conda \
         --conda-frontend conda \
         --configfile test/config/config_provide_rm.yaml \
-        --show-failed-logs \
-        --all-temp
+        --show-failed-logs && rm -rf results

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -62,3 +62,11 @@ jobs:
         --conda-frontend conda \
         --configfile test/config/config.yaml \
         --show-failed-logs
+
+    - name: Test run chr8 and chr21 workflow using provided RM output.
+      run: |
+        snakemake -c 4 -p \
+        --sdm conda \
+        --conda-frontend conda \
+        --configfile test/config/config_provide_rm.yaml \
+        --show-failed-logs

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -61,7 +61,8 @@ jobs:
         --sdm conda \
         --conda-frontend conda \
         --configfile test/config/config.yaml \
-        --show-failed-logs
+        --show-failed-logs \
+        --all-temp
 
     - name: Test run chr8 and chr21 workflow using provided RM output.
       run: |
@@ -69,4 +70,5 @@ jobs:
         --sdm conda \
         --conda-frontend conda \
         --configfile test/config/config_provide_rm.yaml \
-        --show-failed-logs
+        --show-failed-logs \
+        --all-temp

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -31,7 +31,15 @@ if CONTAINER:
 
 wildcard_constraints:
     sample="|".join(MANIFEST.keys()),
+    fname=r"[^\/]*",
     ctg=r"[^\/]*",
+
+
+def convert_seqkit_coord_to_tsv(wc) -> str:
+    # seqkit split converts ':' to '__'
+    chrom, coords = wc.fname.split("__")
+    start, end = coords.split("-")
+    return f"{chrom}\\t{start}\\t{end}\\n"
 
 
 ###
@@ -181,11 +189,28 @@ rule run_rm:
 ###
 
 
+rule intersect_methyl_bed:
+    input:
+        methylation_tsv=rules.get_methylation_bed.output,
+    output:
+        # To make wildcard filename distinct, use - instead of _.
+        methyl_bed=temp(join(OUTPUT_DIR, "bed", "{sample}-{fname}_methyl.bed")),
+    params:
+        bed_tsv=convert_seqkit_coord_to_tsv,
+    log:
+        join(LOG_DIR, "intersect_methyl_bed_{sample}_{fname}.log"),
+    conda:
+        "envs/tools.yaml"
+    shell:
+        """
+        bedtools intersect -a {input.methylation_tsv} -b <(printf "{params.bed_tsv}") > {output.methyl_bed} 2> {log}
+        """
+
+
 rule calc_windows:
     input:
         script=workflow.source_path("scripts/calculate_windows.py"),
-        methylation_tsv=rules.get_methylation_bed.output,
-        target_bed=lambda wc: MANIFEST[wc.sample]["regions"],
+        methylation_tsv=rules.intersect_methyl_bed.output,
     output:
         binned_freq=temp(join(OUTPUT_DIR, "bed", "{sample}_{fname}_binned_freq.bed")),
     log:
@@ -201,10 +226,11 @@ rule calc_windows:
         "envs/python.yaml"
     params:
         window_size=WINDOW,
+        bed_tsv=convert_seqkit_coord_to_tsv,
     shell:
         """
         python {input.script} \
-        --target_bed {input.target_bed} \
+        --target_bed <(printf "{params.bed_tsv}") \
         --methylation_tsv {input.methylation_tsv} \
         --window_size {params.window_size} \
         -p {threads} > {output} 2> {log}
@@ -215,13 +241,6 @@ rule calc_windows:
 # Format RM: Converts Repeatmasker output to bedfile and extracts only ALR annotations
 # Otherwise, use user-provided RepeatMasker
 ###
-
-
-def convert_seqkit_coord_to_tsv(wc) -> str:
-    # seqkit split converts ':' to '__'
-    chrom, coords = wc.fname.split("__")
-    start, end = coords.split("-")
-    return f"{chrom}\\t{start}\\t{end}\\n"
 
 
 rule intersect_user_rm_output:

--- a/workflow/envs/tools.yaml
+++ b/workflow/envs/tools.yaml
@@ -2,7 +2,8 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - repeatmasker==4.1.0
+  # Change from 4.1.0 to 4.1.2.p1 due to inability to install when using strict channel priority
+  - repeatmasker==4.1.2.p1
   - bedtools
   - ont-modkit==0.3.2
   - samtools

--- a/workflow/scripts/cdr_finder.py
+++ b/workflow/scripts/cdr_finder.py
@@ -289,12 +289,13 @@ def main():
                     except pl.exceptions.OutOfBoundsError:
                         cdr_end = cdr_end
 
+                cdr_intervals[chrom].chop(cdr_st, cdr_end)
+                
                 # Add merge distance bp.
                 if bp_merge:
                     cdr_st = cdr_st - bp_merge
                     cdr_end = cdr_end + bp_merge
                 # Trim overlaps.
-                cdr_intervals[chrom].chop(cdr_st, cdr_end)
                 itv_cdr = Interval(cdr_st, cdr_end)
                 cdr_intervals[chrom].add(itv_cdr)
 

--- a/workflow/scripts/cdr_finder.py
+++ b/workflow/scripts/cdr_finder.py
@@ -362,7 +362,7 @@ def main():
                 file=sys.stderr,
             )
 
-        for cdr in cdrs.iter():
+        for cdr in sorted(cdrs.iter()):
             cdr_st, cdr_end = cdr.begin, cdr.end
             if bp_merge:
                 cdr_st += bp_merge


### PR DESCRIPTION
* Changed RM version as 4.1.0 not installable with conda strict priority
* Fixed generating same binned file multiple times by intersecting with fname coords.
* Fixed CDR intervals being non-bookended.
* Fixed CDR intervals being not sorted.
* Added small test for passing RM output.